### PR TITLE
[fix] creates cookies folder if not exists

### DIFF
--- a/linkedin.py
+++ b/linkedin.py
@@ -45,6 +45,8 @@ class Linkedin:
                 self.driver.add_cookie(cookie)
 
     def saveCookies(self):
+        if not os.path.exists(os.path.dirname(self.cookies_path)):
+            os.makedirs(os.path.dirname(self.cookies_path))
         pickle.dump(self.driver.get_cookies() , open(self.cookies_path,"wb"))
     
     def isLoggedIn(self):


### PR DESCRIPTION
this implements the fix from [self.saveCookies() issue #58](https://github.com/wodsuz/EasyApplyJobsBot/issues/58)